### PR TITLE
PEP8ify and Convert Wait Logic to Cancelable Timers

### DIFF
--- a/src/DoorAuthWatchdog2.sh
+++ b/src/DoorAuthWatchdog2.sh
@@ -3,8 +3,8 @@
 PYTHON=/usr/bin/python
 
 function myprocess {
-     $PYTHON /home/pi/DoorAuth/DoorAuth1.7/src/scanForNFC_Unlock.py \
-     | tee -a /home/pi/nfc.log
+     $PYTHON `dirname $0`/scanForNFC_Unlock.py \
+     | tee -a `dirname $0`/nfc.log
 }
 
 

--- a/src/DoorAuthWatchdogButton.sh
+++ b/src/DoorAuthWatchdogButton.sh
@@ -4,7 +4,7 @@ PYTHON=/usr/bin/python
 
 function myprocess {
 
-$PYTHON /home/pi/DoorAuth/DoorAuth1.7/src/scanForButton_Unlock.py >> /home/pi/DoorAuth/DoorAuth1.7/src/error.txt
+$PYTHON `dirname $0`/scanForButton_Unlock.py >> `dirname $0`/error.txt
 
 }
 NOW=$(date +"%b-%d-%y")

--- a/src/DoorAuthWatchdogUSB.sh
+++ b/src/DoorAuthWatchdogUSB.sh
@@ -3,8 +3,8 @@
 PYTHON=/usr/bin/python
 
 function myprocess {
-     $PYTHON /home/pi/DoorAuth/DoorAuth1.7/src/scanForUSB_Unlock.py \
-     | tee -a /home/pi/usb.log
+     $PYTHON `dirname $0`/scanForUSB_Unlock.py \
+     | tee -a `dirname $0`/usb.log
 }
 
 

--- a/src/GPIO_interface.py
+++ b/src/GPIO_interface.py
@@ -27,72 +27,107 @@ def LockDoor():
   GPIO.output(button_pin, GPIO.LOW)
   print("Door Should Now be Locked.")
 
-  
-def WaitToCloseThenLock():
-  #print("Waiting for 10 Seconds before scanning for door closure")
-  time.sleep(7)
-  #input = 0
-  reedSensor_pin = 22
-  doorStateOpen = 0  #reedSensor_pin is has a pullup resistor to 5V
-  doorStateClosed = 1 #reed switch will be connected to ground
+
+from threading import Timer, RLock
+CLOSE_TIMER = {
+  'lock': RLock(),
+  'waiting_timer': None
+}
+
+def ScheduleLockStep(lock_stage, delay=0.5, override=False):
+  with CLOSE_TIMER['lock']:
+    if CLOSE_TIMER['waiting_timer']:
+      if override:
+        # if there's a timer running, kill it
+        CLOSE_TIMER['waiting_timer'].cancel()
+        CLOSE_TIMER['waiting_timer'] = None
+      else:
+        # not overriding, bail
+        return
+    CLOSE_TIMER['waiting_timer'] = Timer(delay, lock_stage)
+    CLOSE_TIMER['waiting_timer'].start()
+
+REED_SENSOR_PIN = 22
+DOOR_STATE_OPEN = 0  #REED_SENSOR_PIN is has a pullup resistor to 5V
+DOOR_STATE_CLOSED = 1 #reed switch will be connected to ground
+BUTTON_STATE_PRESSED = 0
+BUTTON_STATE_RELEASED = 1
+UNLOCK_BUTTON_PIN = 27
+
+
+def CleanTimer():
+  with CLOSE_TIMER['lock']:
+    CLOSE_TIMER['waiting_timer'] = None
+
+def AttemptLock():
+  '''Door lock attempt initiation routine'''
+  CleanTimer()
+  # do work which may include scheduling another timer
   #GPIO.setwarnings(False)
   GPIO.setmode(GPIO.BCM)
-  GPIO.setup(reedSensor_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
-  #input = GPIO.input(reedSensor_pin)
-  #print(input) 
-  print("Awaiting Door To Close")
+  GPIO.setup(REED_SENSOR_PIN, GPIO.IN, pull_up_down=GPIO.PUD_UP)
 
-  while True:
-    input = GPIO.input(reedSensor_pin)
-    print(input)
-    if (input == doorStateClosed):
-      #Check For Debounce
-      print("DoorClosedDetected:  Checking for Debounce")
-      time.sleep(0.5)
-      input = GPIO.input(reedSensor_pin)
-      if (input == doorStateOpen):
-        print("Debounce Failed")
-        continue
-      else:
-        print("Door-Closed-Sensor Debounce Test Passed")
-        time.sleep(3)
-        input = GPIO.input(reedSensor_pin)
-        if (input == doorStateClosed):
-          print("Door Closed for 3 Seconds, Locking Door")
-          #Lock Door
-	  LockDoor()
-          break
-        else:
-          print("Door No Longer Closed, Continuing to wait for door closure.")
-          continue
+  input = GPIO.input(REED_SENSOR_PIN)
+  print("Waiting for door to close, input: %s" % input)
+  if (input != DOOR_STATE_CLOSED):
+    # Door not closed, reschedule check for later
+    ScheduleLockStep(AttemptLock)
+    return
 
+  # Door appears closed, check For Debounce
+  print("DoorClosedDetected:  Checking for Debounce")
+  ScheduleLockStep(DoDebounce)
+
+def DoDebounce():
+  '''Door lock debounce check'''
+  CleanTimer()
+  input = GPIO.input(REED_SENSOR_PIN)
+  if (input == DOOR_STATE_OPEN):
+    print("Debounce Failed")
+    ScheduleLockStep(AttemptLock)
+    return
+
+  print("Door-Closed-Sensor Debounce Test Passed")
+  ScheduleLockStep(FinalDoorCheck, delay=3)
+
+def FinalDoorCheck():
+  '''Make sure someone didn't change their mind right after closing the door and reopen it'''
+  CleanTimer()
+  input = GPIO.input(REED_SENSOR_PIN)
+  if (input != DOOR_STATE_CLOSED):
+    print("Door No Longer Closed, Continuing to wait for door closure.")
+    ScheduleLockStep(AttemptLock)
+    return
+
+  print("Door Closed for 3 Seconds, Locking Door")
+  LockDoor()
+  
+def WaitToCloseThenLock():
+  #print("Waiting for 7 Seconds before scanning for door closure")
+  ScheduleLockStep(AttemptLock, delay=7, override=True)
 
 def PrintReedSwitchState():
-  reedSensor_pin = 22
   GPIO.setmode(GPIO.BCM)
-  GPIO.setup(reedSensor_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+  GPIO.setup(REED_SENSOR_PIN, GPIO.IN, pull_up_down=GPIO.PUD_UP)
 
   while True:
-    input = GPIO.input(reedSensor_pin)
+    input = GPIO.input(REED_SENSOR_PIN)
     print(input)
 
 
 def WaitForButtonUnlockThenLock():
-  buttonPressedState = 0
-  buttonReleasedState = 1
-  unlockButton_pin = 27
   GPIO.setmode(GPIO.BCM)
-  GPIO.setup(unlockButton_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+  GPIO.setup(UNLOCK_BUTTON_PIN, GPIO.IN, pull_up_down=GPIO.PUD_UP)
 
   while True:
-    myResult = GPIO.input(unlockButton_pin)
+    myResult = GPIO.input(UNLOCK_BUTTON_PIN)
     #print(myResult)
-    if (myResult == buttonPressedState):
+    if (myResult == BUTTON_STATE_PRESSED):
       #Check For Debounce
       print("Button Press Detected:  Checking for Debounce")
       time.sleep(0.5)   
-      input = GPIO.input(unlockButton_pin)
-      if (myResult == buttonReleasedState):
+      input = GPIO.input(UNLOCK_BUTTON_PIN)
+      if (myResult == BUTTON_STATE_RELEASED):
         print("Button Press Debounce Failed")
         continue
       else:

--- a/src/GPIO_interface.py
+++ b/src/GPIO_interface.py
@@ -5,18 +5,21 @@ import time
 #import ConfigParser
 #import hashlib
 import RPi.GPIO as GPIO
+from door_utils import get_config_section
 
-REED_SENSOR_PIN = 22
-DOOR_STATE_OPEN = 0  #REED_SENSOR_PIN is has a pullup resistor to 5V
-DOOR_STATE_CLOSED = 1 #reed switch will be connected to ground
-BUTTON_STATE_PRESSED = 0
-BUTTON_STATE_RELEASED = 1
-UNLOCK_BUTTON_PIN = 27
-UNLOCK_RELAY_PIN = 23
-LOCK_RELAY_PIN = 24
-RELAY_TOGGLE_DELAY = 0.25
-CLOSE_TO_LOCK_DELAY = 3
-LOCK_ATTEMPT_BACKOFF_DELAY = 7
+GPIO_CONFIG = get_config_section("GPIO")
+
+REED_SENSOR_PIN = GPIO_CONFIG.get("reed_sensor_pin", 22)
+DOOR_STATE_OPEN = GPIO_CONFIG.get("door_state_open", 0)  #REED_SENSOR_PIN is has a pullup resistor to 5V
+DOOR_STATE_CLOSED = GPIO_CONFIG.get("door_state_closed", 1) #reed switch will be connected to ground
+BUTTON_STATE_PRESSED = GPIO_CONFIG.get("button_state_pressed", 0)
+BUTTON_STATE_RELEASED = GPIO_CONFIG.get("button_state_released", 1)
+UNLOCK_BUTTON_PIN = GPIO_CONFIG.get("unlock_button_pin", 27)
+UNLOCK_RELAY_PIN = GPIO_CONFIG.get("unlock_relay_pin", 23)
+LOCK_RELAY_PIN = GPIO_CONFIG.get("lock_relay_pin", 24)
+RELAY_TOGGLE_DELAY = GPIO_CONFIG.get("relay_toggle_delay", 0.25)
+CLOSE_TO_LOCK_DELAY = GPIO_CONFIG.get("close_to_lock_delay", 3)
+LOCK_ATTEMPT_BACKOFF_DELAY = GPIO_CONFIG.get("lock_attempt_backoff_delay", 7)
 
  # Is it valid?
 def UnlockDoor():

--- a/src/PostToRedQueen.py
+++ b/src/PostToRedQueen.py
@@ -1,9 +1,13 @@
 import requests
 from logger import *
+from door_utils import get_config_section
+
+RQ_CONFIG = get_config_section("RedQueen")
 
 def PostToRedQueen(textToSay):
   try:
-    payload = {"message":textToSay, "channel":"#makerslocal", "isaction":False, "key":"KEYGOESHERE"}
+    payload = {"message":textToSay, "channel":RQ_CONFIG['Channel'], \
+      "isaction":RQ_CONFIG['IsAction'], "key":RQ_CONFIG['Key']}
     r = requests.post("https://crump.space/rq/relay", json = payload)
   except:
     f = open('/home/pi/myPythonErrorFile.txt','w')

--- a/src/door.conf
+++ b/src/door.conf
@@ -1,4 +1,17 @@
 {
+	"GPIO": {
+		"reed_sensor_pin": 22,
+		"door_state_open": 0,
+		"door_state_closed": 1,
+		"button_state_pressed": 0,
+		"button_state_released": 1,
+		"unlock_button_pin": 27,
+		"unlock_relay_pin": 23,
+		"lock_relay_pin": 24,
+		"relay_toggle_delay": 0.25,
+		"close_to_lock_delay": 3,
+		"lock_attempt_backoff_delay": 7
+	},
 	"RedQueen": {
 		"IsAction": False
 		"Key": 13371234

--- a/src/door.conf
+++ b/src/door.conf
@@ -13,8 +13,8 @@
 		"lock_attempt_backoff_delay": 7
 	},
 	"RedQueen": {
-		"IsAction": False
-		"Key": 13371234
+		"IsAction": false,
+		"Key": 13371234,
 		"Channel": "#rqtest"
 	},
 	"SectionTwo": {

--- a/src/door_utils.py
+++ b/src/door_utils.py
@@ -1,0 +1,11 @@
+'''Utilities common to much door functionality'''
+import json
+from os.path import expanduser
+
+CONFIG_FILE = expanduser("~/.doorConfig")
+
+def get_config_section(section_name):
+    '''Get a config section'''
+    with open(CONFIG_FILE, "r") as config_file:
+        json_config = json.load(config_file)
+        return json_config[section_name]

--- a/src/ldapCheck.py
+++ b/src/ldapCheck.py
@@ -3,8 +3,11 @@ import time, os, re, ldap
 import serial
 import sys
 #from cash_api import *
+from door_utils import get_config_section
 
-LDAP_URI = 'ldap://newldap.256.makerslocal.org/'
+LDAP_CONFIG = get_config_section("LDAP")
+
+LDAP_URI = LDAP_CONFIG["Address"]
 
 
 def getAllFromUID(uid):

--- a/src/scanForNFC.py
+++ b/src/scanForNFC.py
@@ -1,5 +1,6 @@
 import json
 import subprocess
+import os
 from ldapCheck import *
 from playSound import *
 
@@ -8,7 +9,7 @@ playSounds = False
 while True:
     # Grab the output from poll.py
     results = subprocess.check_output(['/usr/bin/sudo','/usr/bin/python3',
-'/home/pi/DoorAuth/DoorAuth1.7/src/poll.py'])
+os.path.join(os.path.dirname(__file__), "poll.py")])
     print "Card scanned!"
     print results
 

--- a/src/scanForNFC_Unlock.py
+++ b/src/scanForNFC_Unlock.py
@@ -11,6 +11,7 @@ from whiteListCheck import *
 from writeToDirectory import *
 from logger import *
 from PostToRedQueen import *
+import os
 
 soundPrefix = "Welcome to Makers Local"
 soundSuffix = ""
@@ -23,7 +24,7 @@ try:
   while True:
       # Grab the output from poll.py
       results = subprocess.check_output(['/usr/bin/sudo','/usr/bin/python3',
-  '/home/pi/DoorAuth/DoorAuth1.7/src/poll_old.py'])
+  os.path.join(os.path.dirname(__file__), "poll_old.py")])
       if results:
             log (results)
             log ("NFC detected!")

--- a/src/scanForUSB_Unlock.py
+++ b/src/scanForUSB_Unlock.py
@@ -60,7 +60,7 @@ while 1:
 	  if (IS_WILLIE_ENABLED):        
 	    WriteToDirectory(name)
 	  if (IS_REDQUEEN_ENABLED):
-	    PostToRedQueen("USB Authentication Token Found. Unlocking for " + name)
+	    PostToRedQueen("USB Authentication Token found. Unlocking for " + name)
           WaitToCloseThenLock()
   except KeyboardInterrupt:
     log( "\nBye\n")

--- a/src/whiteListCheck.py
+++ b/src/whiteListCheck.py
@@ -3,7 +3,7 @@ import time, os, re
 import sys
 from xml.dom import minidom
 
-WHITE_LIST_PATH =  "/home/pi/DoorAuth/DoorAuth1.7/src/whiteList.xml"
+WHITE_LIST_PATH = os.path.join(os.path.dirname(__file__), "whiteList.xml")
 
 def isInWhiteList(uid):
   print ("Got this far 2")


### PR DESCRIPTION
This does a lot of cleanup and moves all the hard-coded delays to timers that can be overridden and canceled. This allows the remainder of the code to continue processing inputs while the door close timer spins in the background. The configuration for GPIO pins, LDAP, and RedQueen have been broken out into a config file that currently lives at /root/.doorConfig. This is tested and working code.